### PR TITLE
Updated `url` and `baseUrl`in docusaurus config file

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,10 +10,10 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://pacedsclub.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/website/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
I updated the `url` and `baseurl` in docusaurus.config.ts to "https://pacedsclub.github.io" and "/website/" respectively. This should help fix the following error encountered during deployment: 

> Your Docusaurus site did not load properly.
 A very common reason is a wrong site baseUrl configuration.
 Current configured baseUrl = / (default value)
 We suggest trying baseUrl = /website/

